### PR TITLE
Fix for LoadingImageView's contentmode

### DIFF
--- a/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.h
+++ b/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.h
@@ -43,7 +43,6 @@
 
 @property (nonatomic, weak) id<RZLoadingImageViewDelegate> delegate;
 
-@property (nonatomic, assign) UIViewContentMode imageContentMode;
 @property (nonatomic, assign) BOOL showPlaceholderOnError;
 @property (nonatomic, strong) UIImage *errorPlaceholderImage UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) UIImageRenderingMode imageRenderingMode;

--- a/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.m
+++ b/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.m
@@ -50,7 +50,6 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.contentMode = UIViewContentModeScaleAspectFit;
-        self.imageContentMode = UIViewContentModeScaleAspectFit;
         [self commonInit];
     }
     return self;
@@ -60,7 +59,6 @@
 {
     self = [super initWithCoder:aDecoder];
     if (self){
-        self.imageContentMode = self.contentMode;
         [self commonInit];
     }
     return self;
@@ -91,9 +89,7 @@
 {
     if (loading)
     {
-        // Reset content mode
         self.image = nil;
-        self.contentMode = UIViewContentModeScaleAspectFit;
         [self.loadingSpinner startAnimating];
     }
     else


### PR DESCRIPTION
Hey @ndonald2 - want to take a peak at this?  There was a small bug after 6e99dce where setting the loading image view's imageContentMode didn't do anything.  After @arrouse and I looked at it, we didn't see any strong reason to manually set the UIImageView's contentmode to aspect fit while loading and then setting it back after done loading.
