### PR TITLE
add a parameter to animation block

### DIFF
--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (^RZAnimationBlock)(CGRect keyboardFrame);
+typedef void (^RZAnimationBlock)(BOOL keyboardVisible, CGRect keyboardFrame);
 
 @interface UIViewController (RZKeyboardWatcher)
 

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
@@ -65,6 +65,7 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
     
     CGRect keyboardFrame = [[[notification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     
+    BOOL keyboardVisible = [notification.name isEqualToString:UIKeyboardWillShowNotification];
     if (self.animate)
     {
         UIViewAnimationCurve animationCurve = [[userInfo objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue];
@@ -74,7 +75,7 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
         [UIView animateWithDuration:animationDuration delay:0.0 options:(animationCurve << 16) animations:^{
             if (wSelf.animationBlock)
             {
-                wSelf.animationBlock(keyboardFrame);
+                wSelf.animationBlock(keyboardVisible, keyboardFrame);
                 [wSelf.viewController.view layoutIfNeeded];
             }
         } completion:nil];
@@ -83,7 +84,7 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
     {
         if (self.animationBlock)
         {
-            self.animationBlock(keyboardFrame);
+            self.animationBlock(keyboardVisible, keyboardFrame);
             [self.viewController.view layoutIfNeeded];
         }
     }


### PR DESCRIPTION
@ndonald2  My most common use case for watching keyboard hide/show is to modify the bottom edge inset of a table view. Currently, there's no way to know inside the animation block if the keyboard is being hidden so I can change the bottom inset back to 0. This helps that use case.
