### PR TITLE
Adding the contentMode check for URL requests in addition to path requests

### DIFF
--- a/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.m
+++ b/RZUtils/Components/RZLoadingImageView/RZLoadingImageView.m
@@ -146,6 +146,9 @@
 {
     [self cancelRequest];
     
+    // ensure that we use the correct content mode if we have to change it due to placeholder
+    self.originalContentMode = self.contentMode;
+    
     if (url == nil){
         [self showPlaceholder];
         return;


### PR DESCRIPTION
Looks like we were only setting this on a path request.  Not on a URL request.  Adding that set in.
