### PR TITLE
Inititalize hudBoxView in its getter

### DIFF
--- a/RZUtils/Components/RZHud/RZHud.m
+++ b/RZUtils/Components/RZHud/RZHud.m
@@ -344,9 +344,9 @@
     return _labelText;
 }
 
-- (RZHudBoxView*)hudBoxView
+- (RZHudBoxView *)hudBoxView
 {
-    if(!_hudBoxView)
+    if ( !_hudBoxView )
     {
         RZHudBoxStyle subStyle = self.hudStyle == RZHudStyleBoxLoading ? RZHudBoxStyleLoading : RZHudBoxStyleInfo;
         _hudBoxView = [[RZHudBoxView alloc] initWithStyle:subStyle color:self.hudColor cornerRadius:self.cornerRadius];


### PR DESCRIPTION
Fixes an issue with showHUDWithMessage:inView: where label is not set since hudBoxView is not initialized till then.
