### PR TITLE
Fixing issue from -Wmissing-braces warnings

### DIFF
--- a/RZUtils/Components/RZLoadingImageView/RZImageDecompressionOperation.m
+++ b/RZUtils/Components/RZLoadingImageView/RZImageDecompressionOperation.m
@@ -154,11 +154,11 @@
             if(resizing)
             {
                 CGSize size = [UIImage rz_sizeForImage:compressedImage scaledToSize:imageSize preserveAspectRatio:self.preserveAspect];
-                imageDrawingRect = (CGRect){CGPointZero, size.width, size.height};
+                imageDrawingRect = (CGRect){CGPointZero, {size.width, size.height}};
             }
             else
             {
-                imageDrawingRect = (CGRect){CGPointZero, imageSize.width, imageSize.height};
+                imageDrawingRect = (CGRect){CGPointZero, {imageSize.width, imageSize.height}};
             }
             
             CGContextRef context = CGBitmapContextCreate(NULL,


### PR DESCRIPTION
Super small thing:  If you have the `-Wmissing-braces` warnings enabled as part of `-Wall` you will get yelled at here.
