### PR TITLE
Method for getting enumified screen height.

### DIFF
--- a/RZUtils/Headers/RZUIKitUtilityFunctions.h
+++ b/RZUtils/Headers/RZUIKitUtilityFunctions.h
@@ -64,3 +64,26 @@ inline static UIViewAnimationOptions RZAnimationOptionFromCurve(UIViewAnimationC
     }
     return option;
 }
+
+typedef NS_ENUM(NSUInteger, RZUIScreenHeight)
+{
+    RZUIScreenHeightUnknown = 0,
+    RZUIScreenHeight480 = 480,
+    RZUIScreenHeight568 = 568
+};
+
+inline static RZUIScreenHeight RZUIScreenGetHeight()
+{
+    RZUIScreenHeight screenHeight = [UIScreen mainScreen].bounds.size.height;
+    switch ( screenHeight ) {
+        case RZUIScreenHeight480:
+        case RZUIScreenHeight568:
+            screenHeight = (RZUIScreenHeight)screenHeight;
+            break;
+        default:
+            screenHeight = RZUIScreenHeightUnknown;
+            break;
+    }
+    
+    return screenHeight;
+}


### PR DESCRIPTION
@Raizlabs/maintainers-ios Feedback welcome. This method is an alternative to the raft of device-specific macros out there for conditional layout, such as `IS_IPHONE5`, that won't survive the addition of a third phone screen size.
