### PR TITLE
Removing line about demo project from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RZUtils
 
-This is a collection of helpful utilities and components which makes iOS development quicker and easier.
+A collection of helpful utilities and components for iOS development.
 
 ## Categories Overview
 


### PR DESCRIPTION
@Raizlabs/maintainers-ios SUPER tiny fix. Just getting rid of the line about the demo project in the README, since there isn't one.
