### PR TITLE
RZButtonView touch unhighlight-highlight tracking

### DIFF
--- a/RZUtils/Components/RZButtonView/RZButtonView.m
+++ b/RZUtils/Components/RZButtonView/RZButtonView.m
@@ -69,7 +69,7 @@
 
 - (void)setSubviewsHighlighted:(BOOL)subviewsHighlighted
 {
-    if (_subviewsHighlighted != subviewsHighlighted)
+    if ( _subviewsHighlighted != subviewsHighlighted )
     {
         [self setSubviewsHighlighted:subviewsHighlighted forView:self];
         _subviewsHighlighted = subviewsHighlighted;


### PR DESCRIPTION
@Raizlabs/maintainers-ios This allows `RZButtonView` to unhighlight/highlight similar to how a UIButton highlights when you are dragging your finger around it.
