### PR TITLE
Quick fix for a bug where swipe to reveal didn't work the first time

### DIFF
--- a/RZUtils/Components/RZRevealViewController/RZRevealViewController.m
+++ b/RZUtils/Components/RZRevealViewController/RZRevealViewController.m
@@ -186,7 +186,6 @@
     self.showHiddenOffset = self.view.bounds.size.width  * 0.85;
     self.revealGestureThreshold = CGFLOAT_MAX;
     self.maxDragDistance = self.view.bounds.size.width;
-    self.revealPanGestureRecognizer.enabled = NO;
 }
 
 - (void)initializeGestureRecognizers
@@ -204,10 +203,7 @@
         [self.view addGestureRecognizer:self.revealPanGestureRecognizer];
     }
 
-    if(self.usesEdgeGestureRecognizer)
-    {
-        self.revealPanGestureRecognizer.enabled = NO;
-    }
+    self.revealPanGestureRecognizer.enabled = !self.usesEdgeGestureRecognizer;
 }
 
 #pragma mark - View lifecycle


### PR DESCRIPTION
@Raizlabs/maintainers-ios This is just a quick fix for a bug that didn't allow the revealVC to swipe when it is first loaded.  It would have to be opened and then closed before the swipe would work.
