### PR TITLE
add snapshot method that uses the old -[CALayer renderInContext:] method

### DIFF
--- a/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.h
+++ b/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.h
@@ -139,4 +139,13 @@
  */
 + (UIImage *)rz_imageByCapturingView:(UIView *)view afterScreenUpdate:(BOOL)waitForUpdate;
 
+/**
+ *  Take a snapshot of a supplied UIView and return it as an UIImage*.
+ *
+ *  @param view The UIView to be captured.
+ *
+ *  @return A UIImage created from the supplied UIView.
+ */
++ (UIImage *)rz_imageByRenderingLayerInView:(UIView *)view;
+
 @end

--- a/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.m
+++ b/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.m
@@ -278,4 +278,13 @@ static UIImage * RZBlurredImageInCurrentContext(CGRect imageRect, CGFloat blurRa
     return outputImage;
 }
 
++ (UIImage *)rz_imageByRenderingLayerInView:(UIView *)view
+{
+    UIGraphicsBeginImageContextWithOptions(view.bounds.size, NO, 0.0);
+    [view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *bitmapImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return bitmapImage;
+}
+
 @end


### PR DESCRIPTION
@ndonald2 I needed this method of snapshotting because `rz_imageByCapturingView:afterScreenUpdate:` was too slow and didn't even always work when snapshotting subview hierarchies in `UICollectionViewCell`s. 

If you have any suggestions for documentation to reflect this let me know. 

We could also use the NS_AVAILABLE macros for the two methods, if it would add any benefit.
