### PR TITLE
added object and key path parameters to RZKVOBlock

### DIFF
--- a/RZUtils/Categories/KVO/NSObject+RZBlockKVO.h
+++ b/RZUtils/Categories/KVO/NSObject+RZBlockKVO.h
@@ -28,7 +28,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (^RZKVOBlock)(id object, NSString *keyPath, NSDictionary *change);
+typedef void (^RZKVOBlock)(id object, NSDictionary *change);
 
 /**
  *  Block-based KVO extensions. 

--- a/RZUtils/Categories/KVO/NSObject+RZBlockKVO.m
+++ b/RZUtils/Categories/KVO/NSObject+RZBlockKVO.m
@@ -107,7 +107,7 @@ static char kRZAssociatedObservationsKey;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if ( self.block ) {
-        self.block(object, keyPath, change);
+        self.block(object, change);
     }
 }
 

--- a/Tests/RZUtilsTests/RZBlockKVOTests.m
+++ b/Tests/RZUtilsTests/RZBlockKVOTests.m
@@ -36,7 +36,7 @@
     [testObj rz_addObserver:self
                  forKeyPath:@"aString"
                     options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
-                  withBlock:^(NSDictionary *change) {
+                  withBlock:^(id object, NSDictionary *change) {
                       
                       id value = [change objectForKey:NSKeyValueChangeNewKey];
                       if ( [value isEqual:[NSNull null]] ) {
@@ -69,7 +69,7 @@
         [testObj rz_addObserver:observerObj
                      forKeyPath:@"aString"
                         options:NSKeyValueObservingOptionNew
-                      withBlock:^(NSDictionary *change) {
+                      withBlock:^(id object, NSDictionary *change) {
                           called = YES;
                       }];
     


### PR DESCRIPTION
Changed to RZKVOBlock to include object and keyPath, like the observeValue method does via ordinary KVO.
