### PR TITLE
Fix race condition for cancelling delayed operations

### DIFF
--- a/RZUtils/Components/RZDelayedOperation/RZDelayedOperation.m
+++ b/RZUtils/Components/RZDelayedOperation/RZDelayedOperation.m
@@ -113,7 +113,7 @@ typedef NS_ENUM(NSInteger, RZDelayedOperationState)
             
             self.block();
             
-            if ([NSThread isMainThread]) {
+            if ( [NSThread isMainThread] ) {
                 [self invalidateTimer];
                 [self finish];
             }


### PR DESCRIPTION
@Raizlabs/maintainers-ios 

There was a race condition in the delayed operation due to the fact that the block is dispatched asynchronously (unavoidable -- we can't use `dispatch_sync` because there may be reentrancy, creating a deadlock).

Fixed by checking the cancelled state in the dispatched block so that if it was cancelled before the async block is executed, nothing will happen.
