### PR TITLE
Adding a keyboardVisible property to the completion block.

### DIFF
--- a/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.m
+++ b/RZUtils/Categories/UIImage/UIImage+RZSnapshotHelpers.m
@@ -236,7 +236,7 @@ static UIImage * RZBlurredImageInCurrentContext(CGRect imageRect, CGFloat blurRa
     UIImage *unblurredImage = nil;
     UIImage *blurredImage = nil;
     
-    CGRect imageRect = { CGPointZero, CGRectGetWidth(view.bounds), CGRectGetHeight(view.bounds) };
+    CGRect imageRect = { CGPointZero, { CGRectGetWidth(view.bounds), CGRectGetHeight(view.bounds) } };
     CGFloat scale = [[UIScreen mainScreen] scale];
     UIGraphicsBeginImageContextWithOptions(imageRect.size, NO, scale);
     

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
@@ -5,15 +5,15 @@
 //  Copyright (c) 2014 Raizlabs. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
-typedef void (^RZAnimationBlock)(BOOL keyboardVisible, CGRect keyboardFrame);
-typedef void (^RZAnimationCompletionBlock)(BOOL finished);
+typedef void (^RZKeyboardAnimationBlock)(BOOL keyboardVisible, CGRect keyboardFrame);
+typedef void (^RZKeyboardAnimationCompletionBlock)(BOOL finished, BOOL keyboardVisible);
 
 @interface UIViewController (RZKeyboardWatcher)
 
-- (void)rz_watchKeyboardShowWithAnimations:(RZAnimationBlock)animations animated:(BOOL)animated;
-- (void)rz_watchKeyboardShowWithAnimations:(RZAnimationBlock)animations completion:(RZAnimationCompletionBlock)completion animated:(BOOL)animated;
+- (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations animated:(BOOL)animated;
+- (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations completion:(RZKeyboardAnimationCompletionBlock)completion animated:(BOOL)animated;
 - (void)rz_unwatchKeyboard;
 
 @end

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
@@ -2,18 +2,73 @@
 //  UIViewController+RZKeyboardWatcher.h
 //
 //  Created by Joe Mahon on 1/29/14.
-//  Copyright (c) 2014 Raizlabs. All rights reserved.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 @import Foundation;
 
+/**
+ *  The animation block for the keyboard showing.  Called using a standard UIView animation matching the 
+ *  keyboard's presentation curve and it's duration.
+ *
+ *  @param keyboardVisible If the keyboard is visible.  YES if it is being presented, NO otherwise
+ *  @param keyboardFrame   The final frame of the keyboard.
+ */
 typedef void (^RZKeyboardAnimationBlock)(BOOL keyboardVisible, CGRect keyboardFrame);
+
+/**
+ *  The completion block for the RZKeyboardAnimationBlock.
+ *
+ *  @param finished        If the animation finished successfully.
+ *  @param keyboardVisible If the keyboard is visible.
+ */
 typedef void (^RZKeyboardAnimationCompletionBlock)(BOOL finished, BOOL keyboardVisible);
 
 @interface UIViewController (RZKeyboardWatcher)
 
+/**
+ *  Adds an observer of the keyboard.  Must make sure to unwatch the keyboard later and if using `self`,
+ *  should use a weak reference.
+ *
+ *  @param animations The animation block to be executed when the keyboard state is changed.
+ *  @param animated   If the animation block should be animated or not.
+ */
 - (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations animated:(BOOL)animated;
+
+/**
+ *  Adds an observer of the keyboard.  Must make sure to unwatch the keyboard later and if using `self`,
+ *  should use a weak reference.
+ *
+ *  @param animations The animation block to be executed when the keyboard state is changed.
+ *  @param completion The completion block that gets called after the animation completes.
+ *  @param animated   if the animation block should be animated or not.
+ */
 - (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations completion:(RZKeyboardAnimationCompletionBlock)completion animated:(BOOL)animated;
+
+/**
+ *  Removes the observer of the keyboard.
+ */
 - (void)rz_unwatchKeyboard;
 
 @end

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
--#import <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
 /**
  *  The animation block for the keyboard showing.  Called using a standard UIView animation matching the 

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.h
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-@import Foundation;
+-#import <Foundation/Foundation.h>
 
 /**
  *  The animation block for the keyboard showing.  Called using a standard UIView animation matching the 

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
@@ -6,18 +6,18 @@
 //
 
 #import "UIViewController+RZKeyboardWatcher.h"
-#import <objc/runtime.h>
+@import ObjectiveC.runtime;
 
 static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKey;
 
 @interface RZKeyboardAnimationDelegate : NSObject
 
-@property (copy, nonatomic) RZAnimationBlock animationBlock;
-@property (copy, nonatomic) RZAnimationCompletionBlock completionBlock;
+@property (copy, nonatomic) RZKeyboardAnimationBlock animationBlock;
+@property (copy, nonatomic) RZKeyboardAnimationCompletionBlock completionBlock;
 @property (weak, nonatomic) UIViewController *viewController;
 @property (assign, nonatomic) BOOL animate;
 
-- (instancetype)initWithAnimationBlock:(RZAnimationBlock)animations completion:(RZAnimationCompletionBlock)completion andViewController:(UIViewController *)vc;
+- (instancetype)initWithAnimationBlock:(RZKeyboardAnimationBlock)animations completion:(RZKeyboardAnimationCompletionBlock)completion andViewController:(UIViewController *)vc;
 - (void)keyboardWillShow:(NSNotification *)notification;
 - (void)keyboardWillHide:(NSNotification *)notification;
 - (void)startKeyboardObservers;
@@ -27,7 +27,7 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
 
 @implementation RZKeyboardAnimationDelegate
 
-- (instancetype)initWithAnimationBlock:(RZAnimationBlock)animations completion:(RZAnimationCompletionBlock)completion andViewController:(UIViewController *)vc
+- (instancetype)initWithAnimationBlock:(RZKeyboardAnimationBlock)animations completion:(RZKeyboardAnimationCompletionBlock)completion andViewController:(UIViewController *)vc
 {
     self = [super init];
     if ( self != nil ) {
@@ -82,14 +82,18 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
                                  [wSelf.viewController.view layoutIfNeeded];
                              }
                          }
-                         completion:self.completionBlock];
+                         completion:^(BOOL finished) {
+                             if ( self.completionBlock ) {
+                                 self.completionBlock(finished, keyboardVisible);
+                             }
+                         }];
     }
     else {
         if ( self.animationBlock ) {
             self.animationBlock(keyboardVisible, keyboardFrame);
             [self.viewController.view layoutIfNeeded];
             if ( self.completionBlock ) {
-                self.completionBlock(YES);
+                self.completionBlock(YES,keyboardVisible);
             }
         }
     }
@@ -105,12 +109,12 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
 
 @implementation UIViewController (KeyboardWatcher)
 
-- (void)rz_watchKeyboardShowWithAnimations:(RZAnimationBlock)animations animated:(BOOL)animated
+- (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations animated:(BOOL)animated
 {
     [self rz_watchKeyboardShowWithAnimations:animations completion:nil animated:animated];
 }
 
-- (void)rz_watchKeyboardShowWithAnimations:(RZAnimationBlock)animations completion:(RZAnimationCompletionBlock)completion animated:(BOOL)animated
+- (void)rz_watchKeyboardShowWithAnimations:(RZKeyboardAnimationBlock)animations completion:(RZKeyboardAnimationCompletionBlock)completion animated:(BOOL)animated
 {
     if ( animations ) {
         RZKeyboardAnimationDelegate *animationDelegate = [[RZKeyboardAnimationDelegate alloc] initWithAnimationBlock:animations completion:completion andViewController:self];

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
@@ -93,14 +93,13 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
         UIViewAnimationCurve animationCurve = [[userInfo objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue];
         double animationDuration = [[userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
         
-        __weak RZKeyboardAnimationDelegate *wSelf = self;
         [UIView animateWithDuration:animationDuration
                               delay:0.0
                             options:( animationCurve << 16 )
                          animations:^{
-                             if ( wSelf.animationBlock != nil ) {
-                                 wSelf.animationBlock(keyboardVisible, keyboardFrame);
-                                 [wSelf.viewController.view layoutIfNeeded];
+                             if ( self.animationBlock != nil ) {
+                                 self.animationBlock(keyboardVisible, keyboardFrame);
+                                 [self.viewController.view layoutIfNeeded];
                              }
                          }
                          completion:^(BOOL finished) {

--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
@@ -2,7 +2,28 @@
 //  UIViewController+RZKeyboardWatcher.m
 //
 //  Created by Joe Mahon on 1/29/14.
-//  Copyright (c) 2014 Raizlabs. All rights reserved.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import "UIViewController+RZKeyboardWatcher.h"
@@ -77,22 +98,22 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
                               delay:0.0
                             options:( animationCurve << 16 )
                          animations:^{
-                             if ( wSelf.animationBlock ) {
+                             if ( wSelf.animationBlock != nil ) {
                                  wSelf.animationBlock(keyboardVisible, keyboardFrame);
                                  [wSelf.viewController.view layoutIfNeeded];
                              }
                          }
                          completion:^(BOOL finished) {
-                             if ( self.completionBlock ) {
+                             if ( self.completionBlock != nil ) {
                                  self.completionBlock(finished, keyboardVisible);
                              }
                          }];
     }
     else {
-        if ( self.animationBlock ) {
+        if ( self.animationBlock != nil ) {
             self.animationBlock(keyboardVisible, keyboardFrame);
             [self.viewController.view layoutIfNeeded];
-            if ( self.completionBlock ) {
+            if ( self.completionBlock != nil ) {
                 self.completionBlock(YES,keyboardVisible);
             }
         }


### PR DESCRIPTION

Fixes a warning in `UIImage+RZSnapshotHelpers`
Adds a keyboardVisible property to the completion block of the keyboard listener.  

**NOTE** this changes the method signature so I wouldn't recommend pushing this to master until we have more changes that need to go in.