### PR TITLE
Fix unbalanced called to begin/end appearance selectors

### DIFF
--- a/RZUtils/Components/RZSingleChildContainerViewController/RZSingleChildContainerViewController.m
+++ b/RZUtils/Components/RZSingleChildContainerViewController/RZSingleChildContainerViewController.m
@@ -53,7 +53,7 @@ static NSTimeInterval kRZSingleChildContainerAlphaTransitionerAnimationDuration 
 
 @property (nonatomic, strong) NSMutableArray *viewLoadedBlocks;
 
-@property (weak, nonatomic) id viewControllerOnWhichWeCalledBegin;
+@property (weak, nonatomic) UIViewController *viewControllerOnWhichWeCalledBegin;
 
 @end
 


### PR DESCRIPTION
This is to fix a case I was seeing where we were calling `beginAppearanceTransition:animated` while `self.currentContentViewController` was still `nil`, and then calling `endAppearanceTransition` when it was no longer `nil`. This led to unbalanced calls.
