### PR TITLE
Add auto layout helpers for reducing outward constraints

### DIFF
--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
@@ -196,9 +196,9 @@
 - (NSLayoutConstraint *)rz_pinWidthToView:(UIView *)view multiplier:(CGFloat)multiplier;
 
 /**
- *  Pin the receiver's width to a constant.
+ *  Pin the receiver's height to a constant.
  *
- *  @param width Deisred height.
+ *  @param height Deisred height.
  *
  *  @return The pinned height constraint that was added.
  */

--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
@@ -107,6 +107,62 @@
  */
 - (NSLayoutConstraint*)rz_pinnedCenterYConstraint;
 
+/**
+ *  Return the receiver's bottom-to-top constraints, if any exist.
+ *
+ *  @return The constraints or nil.
+ */
+- (NSArray *)rz_bottomToTopConstraints;
+
+/**
+ *  Return the receiver's top-to-bottom constraints, if any exist.
+ *
+ *  @return The constraints or nil.
+ */
+- (NSArray *)rz_topToBottomConstraints;
+
+/**
+ *  Return the receiver's left-to-right constraints, if any exist.
+ *
+ *  @return The constraints or nil.
+ */
+- (NSArray *)rz_leftToRightConstraints;
+
+/**
+ *  Return the receiver's right-to-left constraints, if any exist.
+ *
+ *  @return The constraints or nil.
+ */
+- (NSArray *)rz_rightToLeftConstraints;
+
+/**
+ *  Return the receiver's only bottom-to-top constraint.
+ *
+ *  @return The constraint or nil.
+ */
+- (NSLayoutConstraint *)rz_onlyBottomToTopConstraint;
+
+/**
+ *  Return the receiver's only top-to-bottom constraint.
+ *
+ *  @return The constraint or nil.
+ */
+- (NSLayoutConstraint *)rz_onlyTopToBottomConstraint;
+
+/**
+ *  Return the receiver's only left-to-right constraint.
+ *
+ *  @return The constraint or nil.
+ */
+- (NSLayoutConstraint *)rz_onlyLeftToRightConstraint;
+
+/**
+ *  Return the receiver's only right-to-left constraint.
+ *
+ *  @return The constraint or nil.
+ */
+- (NSLayoutConstraint *)rz_onlyRightToLeftConstraint;
+
 /** @name Constraint Creation */
 
 /**
@@ -265,6 +321,62 @@
  *  @return The constraint that was added.
  */
 - (NSLayoutConstraint *)rz_pinRightSpaceToSuperviewWithPaddingGreaterThanOrEqualTo:(CGFloat)padding;
+
+/**
+ *  Attach the bottom of the receiver to the top of the given view with a
+ *  fixed amount of padding.
+ *
+ *  @param view    The view that the receiver will be on top of.
+ *  @param padding The amount of padding between the bottom of the receiver
+ *                 and the top of @c view.
+ *
+ *  @warning The receiver must have a superview when this method is called.
+ *
+ *  @return The bottom-to-top constraint that was added.
+ */
+- (NSLayoutConstraint *)rz_attachBottomToTopOfView:(UIView *)view withPadding:(CGFloat)padding;
+
+/**
+ *  Attach the top of the receiver to the bottom of the given view with a
+ *  fixed amount of padding.
+ *
+ *  @param view    The view that the receiver will be below.
+ *  @param padding The amount of padding between the top of the receiver
+ *                 and the bottom of @c view.
+ *
+ *  @warning The receiver must have a superview when this method is called.
+ *
+ *  @return The top-to-bottom constraint that was added.
+ */
+- (NSLayoutConstraint *)rz_attachTopToBottomOfView:(UIView *)view withPadding:(CGFloat)padding;
+
+/**
+ *  Attach the left side of the receiver to the right of the given view with a
+ *  fixed amount of padding.
+ *
+ *  @param view    The view that the receiver will be to the right of.
+ *  @param padding The amount of padding between the left side of the receiver
+ *                 and the right of @c view.
+ *
+ *  @warning The receiver must have a superview when this method is called.
+ *
+ *  @return The left-to-right constraint that was added.
+ */
+- (NSLayoutConstraint *)rz_attachLeftToRightOfView:(UIView *)view withPadding:(CGFloat)padding;
+
+/**
+ *  Attach the right side of the receiver to the left of the given view with a
+ *  fixed amount of padding.
+ *
+ *  @param view    The view that the receiver will be to the left of.
+ *  @param padding The amount of padding between the right side of the receiver
+ *                 and the left of @c view.
+ *
+ *  @warning The receiver must have a superview when this method is called.
+ *
+ *  @return The right-to-left constraint that was added.
+ */
+- (NSLayoutConstraint *)rz_attachRightToLeftOfView:(UIView *)view withPadding:(CGFloat)padding;
 
 /**
  *  Pin all sides of the receiver to its superview's sides with fixed insets.

--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
@@ -138,12 +138,16 @@
 /**
  *  Return the receiver's only bottom-to-top constraint.
  *
+ *  @warning The receiver is expected to have only one bottom-to-top constraint.
+ *
  *  @return The constraint or nil.
  */
 - (NSLayoutConstraint *)rz_onlyBottomToTopConstraint;
 
 /**
  *  Return the receiver's only top-to-bottom constraint.
+ *
+ *  @warning The receiver is expected to have only one bottom-to-top constraint.
  *
  *  @return The constraint or nil.
  */
@@ -152,12 +156,16 @@
 /**
  *  Return the receiver's only left-to-right constraint.
  *
+ *  @warning The receiver is expected to have only one bottom-to-top constraint.
+ *
  *  @return The constraint or nil.
  */
 - (NSLayoutConstraint *)rz_onlyLeftToRightConstraint;
 
 /**
  *  Return the receiver's only right-to-left constraint.
+ *
+ *  @warning The receiver is expected to have only one bottom-to-top constraint.
  *
  *  @return The constraint or nil.
  */

--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.h
@@ -147,7 +147,7 @@
 /**
  *  Return the receiver's only top-to-bottom constraint.
  *
- *  @warning The receiver is expected to have only one bottom-to-top constraint.
+ *  @warning The receiver is expected to have only one top-to-bottom constraint.
  *
  *  @return The constraint or nil.
  */
@@ -156,7 +156,7 @@
 /**
  *  Return the receiver's only left-to-right constraint.
  *
- *  @warning The receiver is expected to have only one bottom-to-top constraint.
+ *  @warning The receiver is expected to have only one left-to-right constraint.
  *
  *  @return The constraint or nil.
  */
@@ -165,7 +165,7 @@
 /**
  *  Return the receiver's only right-to-left constraint.
  *
- *  @warning The receiver is expected to have only one bottom-to-top constraint.
+ *  @warning The receiver is expected to have only one right-to-left constraint.
  *
  *  @return The constraint or nil.
  */

--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.m
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.m
@@ -222,6 +222,106 @@
     return constraint;
 }
 
+- (NSArray *)rz_bottomToTopConstraints
+{
+    if ( self.superview == nil ) {
+        return nil;
+    }
+
+    NSMutableArray *constraints = [NSMutableArray array];
+    for ( NSLayoutConstraint *c in self.superview.constraints ) {
+        if ((( c.firstItem == self && [c.secondItem superview] == self.superview ) && c.firstAttribute == NSLayoutAttributeBottom && c.secondAttribute == NSLayoutAttributeTop ) ||
+            (( c.secondItem == self && [c.firstItem superview] == self.superview ) && c.secondAttribute == NSLayoutAttributeBottom && c.firstAttribute == NSLayoutAttributeTop )) {
+
+            [constraints addObject:c];
+        }
+    }
+
+    return constraints.count ? [constraints copy] : nil;
+}
+
+- (NSArray *)rz_topToBottomConstraints
+{
+    if ( self.superview == nil ) {
+        return nil;
+    }
+
+    NSMutableArray *constraints = [NSMutableArray array];
+    for ( NSLayoutConstraint *c in self.superview.constraints ) {
+        if ((( c.firstItem == self && [c.secondItem superview] == self.superview ) && c.firstAttribute == NSLayoutAttributeTop && c.secondAttribute == NSLayoutAttributeBottom ) ||
+            (( c.secondItem == self && [c.firstItem superview] == self.superview ) && c.secondAttribute == NSLayoutAttributeTop && c.firstAttribute == NSLayoutAttributeBottom )) {
+
+            [constraints addObject:c];
+        }
+    }
+
+    return constraints.count ? [constraints copy] : nil;
+}
+
+- (NSArray *)rz_leftToRightConstraints
+{
+    if ( self.superview == nil ) {
+        return nil;
+    }
+
+    NSMutableArray *constraints = [NSMutableArray array];
+    for ( NSLayoutConstraint *c in self.superview.constraints ) {
+        if ((( c.firstItem == self && [c.secondItem superview] == self.superview ) && c.firstAttribute == NSLayoutAttributeLeft && c.secondAttribute == NSLayoutAttributeRight ) ||
+            (( c.secondItem == self && [c.firstItem superview] == self.superview ) && c.secondAttribute == NSLayoutAttributeRight && c.firstAttribute == NSLayoutAttributeLeft )) {
+
+            [constraints addObject:c];
+        }
+    }
+
+    return constraints.count ? [constraints copy] : nil;
+}
+
+- (NSArray *)rz_rightToLeftConstraints
+{
+    if ( self.superview == nil ) {
+        return nil;
+    }
+
+    NSMutableArray *constraints = [NSMutableArray array];
+    for ( NSLayoutConstraint *c in self.superview.constraints ) {
+        if ((( c.firstItem == self && [c.secondItem superview] == self.superview ) && c.firstAttribute == NSLayoutAttributeRight && c.secondAttribute == NSLayoutAttributeLeft ) ||
+            (( c.secondItem == self && [c.firstItem superview] == self.superview ) && c.secondAttribute == NSLayoutAttributeLeft && c.firstAttribute == NSLayoutAttributeRight )) {
+
+            [constraints addObject:c];
+        }
+    }
+
+    return constraints.count ? [constraints copy] : nil;
+}
+
+- (NSLayoutConstraint *)rz_onlyBottomToTopConstraint
+{
+    NSArray *constraints = [self rz_bottomToTopConstraints];
+    NSAssert(constraints.count == 1, @"More constraints than expected");
+    return [constraints lastObject];
+}
+
+- (NSLayoutConstraint *)rz_onlyTopToBottomConstraint
+{
+    NSArray *constraints = [self rz_topToBottomConstraints];
+    NSAssert(constraints.count == 1, @"More constraints than expected");
+    return [constraints lastObject];
+}
+
+- (NSLayoutConstraint *)rz_onlyLeftToRightConstraint
+{
+    NSArray *constraints = [self rz_leftToRightConstraints];
+    NSAssert(constraints.count == 1, @"More constraints than expected");
+    return [constraints lastObject];
+}
+
+- (NSLayoutConstraint *)rz_onlyRightToLeftConstraint
+{
+    NSArray *constraints = [self rz_rightToLeftConstraints];
+    NSAssert(constraints.count == 1, @"More constraints than expected");
+    return [constraints lastObject];
+}
+
 # pragma mark - Constraint Creation
 
 - (NSLayoutConstraint *)rz_pinWidthTo:(CGFloat)width
@@ -579,6 +679,70 @@
     [self.superview addConstraint:c];
 
     return c;
+}
+
+- (NSLayoutConstraint *)rz_attachBottomToTopOfView:(UIView *)view withPadding:(CGFloat)padding
+{
+    NSParameterAssert(view);
+    NSAssert(self.superview != nil, @"Must have superview");
+
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeTop
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:view
+                                                                  attribute:NSLayoutAttributeBottom
+                                                                 multiplier:1.0f
+                                                                   constant:padding];
+    [self.superview addConstraint:constraint];
+    return constraint;
+}
+
+- (NSLayoutConstraint *)rz_attachTopToBottomOfView:(UIView *)view withPadding:(CGFloat)padding
+{
+    NSParameterAssert(view);
+    NSAssert(self.superview != nil, @"Must have superview");
+
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeBottom
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:view
+                                                                  attribute:NSLayoutAttributeTop
+                                                                 multiplier:1.0f
+                                                                   constant:-padding];
+    [self.superview addConstraint:constraint];
+    return constraint;
+}
+
+- (NSLayoutConstraint *)rz_attachLeftToRightOfView:(UIView *)view withPadding:(CGFloat)padding
+{
+    NSParameterAssert(view);
+    NSAssert(self.superview != nil, @"Must have superview");
+
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeLeft
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:view
+                                                                  attribute:NSLayoutAttributeRight
+                                                                 multiplier:1.0f
+                                                                   constant:padding];
+    [self.superview addConstraint:constraint];
+    return constraint;
+}
+
+- (NSLayoutConstraint *)rz_attachRightToLeftOfView:(UIView *)view withPadding:(CGFloat)padding
+{
+    NSParameterAssert(view);
+    NSAssert(self.superview != nil, @"Must have superview");
+
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeRight
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:view
+                                                                  attribute:NSLayoutAttributeLeft
+                                                                 multiplier:1.0f
+                                                                   constant:-padding];
+    [self.superview addConstraint:constraint];
+    return constraint;
 }
 
 - (NSArray *)rz_fillContainerWithInsets:(UIEdgeInsets)insets

--- a/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.m
+++ b/RZUtils/Categories/UIView/UIView+RZAutoLayoutHelpers.m
@@ -685,6 +685,7 @@
 {
     NSParameterAssert(view);
     NSAssert(self.superview != nil, @"Must have superview");
+    NSAssert(view.superview != nil, @"Must have superview");
 
     NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
                                                                   attribute:NSLayoutAttributeTop
@@ -701,6 +702,7 @@
 {
     NSParameterAssert(view);
     NSAssert(self.superview != nil, @"Must have superview");
+    NSAssert(view.superview != nil, @"Must have superview");
 
     NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
                                                                   attribute:NSLayoutAttributeBottom
@@ -717,6 +719,7 @@
 {
     NSParameterAssert(view);
     NSAssert(self.superview != nil, @"Must have superview");
+    NSAssert(view.superview != nil, @"Must have superview");
 
     NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
                                                                   attribute:NSLayoutAttributeLeft
@@ -733,6 +736,7 @@
 {
     NSParameterAssert(view);
     NSAssert(self.superview != nil, @"Must have superview");
+    NSAssert(view.superview != nil, @"Must have superview");
 
     NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self
                                                                   attribute:NSLayoutAttributeRight


### PR DESCRIPTION
These helpers, authored by @KingOfBrian, allow you to position a view relative to another view in the hierarchy. This reduces the need for the visual formatting language, and cuts down on the number of constraints that are relative to the superview.