### PR TITLE
Use a max scale of 2 on RZBorders

### DIFF
--- a/RZUtils/Categories/UIView/UIView+RZBorders.m
+++ b/RZUtils/Categories/UIView/UIView+RZBorders.m
@@ -382,7 +382,7 @@ static const CGFloat kRZBorderMaxScale = 2.0f;
         CGContextDrawImage(ctx, fullRect, [maskImage CGImage]);
 
         UIEdgeInsets stretchInsets = UIEdgeInsetsMake(floor(imgSize.height * 0.5), floor(imgSize.width * 0.5), floor(imgSize.height * 0.5), floor(imgSize.width * 0.5));
-
+        
         borderImage = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:stretchInsets
                                                                                   resizingMode:UIImageResizingModeStretch];
         UIGraphicsEndImageContext();

--- a/RZUtils/Categories/UIView/UIView+RZBorders.m
+++ b/RZUtils/Categories/UIView/UIView+RZBorders.m
@@ -6,7 +6,7 @@
 
 // Copyright 2014 Raizlabs and other contributors
 // http://raizlabs.com/
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -14,10 +14,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -32,6 +32,11 @@
 #import <QuartzCore/QuartzCore.h>
 
 static char kRZBorderViewKey;
+
+// A 3x scale is causing bad math which causes bad hairline views. For a quick fix we
+// are just having a scale of 2 as the max.
+// In the future we should go about adding borders as just 1 px UIViews with constraints
+static const CGFloat kRZBorderMaxScale = 2.0f;
 
 @interface RZBorderedImageView : UIImageView
 
@@ -76,7 +81,7 @@ static char kRZBorderViewKey;
         [self addSubview:imgView];
         objc_setAssociatedObject(self, &kRZBorderViewKey, imgView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    
+
     imgView.backgroundColor = [UIColor clearColor];
     imgView.opaque = NO;
 }
@@ -92,7 +97,7 @@ static char kRZBorderViewKey;
         [self addSubview:imgView];
         objc_setAssociatedObject(self, &kRZBorderViewKey, imgView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    
+
     imgView.backgroundColor = [UIColor clearColor];
     imgView.opaque = NO;
 }
@@ -119,7 +124,7 @@ static char kRZBorderViewKey;
     if (self)
     {
         self.userInteractionEnabled = NO;
-        self.contentScaleFactor = [[UIScreen mainScreen] scale];
+        self.contentScaleFactor = fminf(kRZBorderMaxScale, [[UIScreen mainScreen] scale]);
     }
     return self;
 }
@@ -127,7 +132,7 @@ static char kRZBorderViewKey;
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    
+
     // always keep me at the front
     self.frame = self.superview.bounds;
     [self.superview bringSubviewToFront:self];
@@ -162,16 +167,16 @@ static char kRZBorderViewKey;
     static NSMutableDictionary * s_cbiCache = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        
+
         s_cbiCache = [NSMutableDictionary dictionary];
-        
+
         // Automatically clear the cache in low-memory situations. Should be a rare occurrence.
         // This notification observation will be valid for the application lifetime - no need to ever remove the observer.
         [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
             [[[RZBorderedImageView class] maskingImageCache] removeAllObjects];
             [[[RZBorderedImageView class] coloredBorderImageCache] removeAllObjects];
         }];
-        
+
     });
     return s_cbiCache;
 }
@@ -181,9 +186,9 @@ static char kRZBorderViewKey;
 - (UIImage *)maskingImageForMask:(RZViewBorderMask)mask width:(CGFloat)width
 {
     // must round the width to nearest pixel for current screen scale
-    CGFloat scale = [[UIScreen mainScreen] scale];
+    CGFloat scale = fminf(kRZBorderMaxScale, [[UIScreen mainScreen] scale]);
     width = round(width * scale) / scale;
-    
+
     NSString *cacheKey = [NSString stringWithFormat:@"%lu_%.2f", (unsigned long)mask, width];
     UIImage *maskImage = [[[self class] maskingImageCache] objectForKey:cacheKey];
     if (maskImage == nil)
@@ -191,15 +196,15 @@ static char kRZBorderViewKey;
         CGFloat imgDim = ceilf(width * 3);
         CGSize imgSize = CGSizeMake(imgDim, imgDim);
 
-        UIGraphicsBeginImageContextWithOptions(imgSize, NO, [[UIScreen mainScreen] scale]);
-        
+        UIGraphicsBeginImageContextWithOptions(imgSize, NO, fminf(kRZBorderMaxScale, [[UIScreen mainScreen] scale]));
+
         CGContextRef ctx = UIGraphicsGetCurrentContext();
 
         CGRect fullRect = (CGRect){CGPointZero, imgSize};
         CGContextClearRect(ctx, fullRect);
-        
+
         CGColorRef maskImageColorRef = [[UIColor whiteColor] CGColor];
-        
+
         CGContextSetStrokeColorWithColor(ctx, maskImageColorRef);
         CGContextSetLineWidth(ctx, width);
 
@@ -239,7 +244,7 @@ static char kRZBorderViewKey;
             segArray[segCount++] = start;
             segArray[segCount++] = end;
         }
-        
+
         CGContextStrokeLineSegments(ctx, segArray, segCount);
 
         maskImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -251,51 +256,51 @@ static char kRZBorderViewKey;
 
         UIGraphicsEndImageContext();
     }
-    
+
     return maskImage;
 }
 
 - (UIImage *)maskingImageForCornerRadius:(CGFloat)radius width:(CGFloat)width
 {
     // must round the width to nearest pixel for current screen scale
-    CGFloat scale = [[UIScreen mainScreen] scale];
+    CGFloat scale = fminf(kRZBorderMaxScale, [[UIScreen mainScreen] scale]);
     width = round(width * scale) / scale;
-    
+
     NSString *cacheKey = [NSString stringWithFormat:@"%.2f_%.2f", radius, width];
     UIImage *maskImage = [[[self class] maskingImageCache] objectForKey:cacheKey];
     if (maskImage == nil)
     {
         CGFloat imgDim = ceilf((width * 3) + (radius * 2));
         CGSize imgSize = CGSizeMake(imgDim, imgDim);
-        
+
         UIGraphicsBeginImageContextWithOptions(imgSize, NO, 0);
-        
+
         CGContextRef ctx = UIGraphicsGetCurrentContext();
-        
+
         CGRect fullRect = (CGRect){CGPointZero, imgSize};
         CGContextClearRect(ctx, fullRect);
-        
+
         CGColorRef maskImageColorRef = [[UIColor whiteColor] CGColor];
-        
+
         CGContextSetStrokeColorWithColor(ctx, maskImageColorRef);
         CGContextSetLineWidth(ctx, width);
-        
+
         CGRect roundedRectFrame = CGRectInset(fullRect, width / 2, width / 2);
         CGPathRef roundedRectPath = CGPathCreateWithRoundedRect(roundedRectFrame, radius, radius, NULL);
         CGContextAddPath(ctx, roundedRectPath);
         CGContextStrokePath(ctx);
         CGPathRelease(roundedRectPath);
-        
+
         maskImage = UIGraphicsGetImageFromCurrentImageContext();
-        
+
         if (maskImage)
         {
             [[[self class] maskingImageCache] setObject:maskImage forKey:cacheKey];
         }
-        
+
         UIGraphicsEndImageContext();
     }
-    
+
     return maskImage;
 }
 
@@ -305,19 +310,19 @@ static char kRZBorderViewKey;
     CGFloat r, g, b, a;
     [color getRed:&r green:&g blue:&b alpha:&a];
     NSString *cacheKey = [NSString stringWithFormat:@"%lu_%.2f-%lu_%lu_%lu_%lu",
-                    (unsigned long)mask,
-                    width,
-                    (unsigned long)(r * 255),
-                    (unsigned long)(g * 255),
-                    (unsigned long)(b * 255),
-                    (unsigned long)(a * 255)];
+                          (unsigned long)mask,
+                          width,
+                          (unsigned long)(r * 255),
+                          (unsigned long)(g * 255),
+                          (unsigned long)(b * 255),
+                          (unsigned long)(a * 255)];
 
     UIImage *borderImage = [[[self class] coloredBorderImageCache] objectForKey:cacheKey];
     if (borderImage == nil)
     {
         UIImage *maskImage = [self maskingImageForMask:mask width:width];
         borderImage = [self borderImageWithMaskImage:maskImage color:color];
-        
+
         if (borderImage)
         {
             [[[self class] coloredBorderImageCache] setObject:borderImage forKey:cacheKey];
@@ -338,46 +343,46 @@ static char kRZBorderViewKey;
                           (unsigned long)(g * 255),
                           (unsigned long)(b * 255),
                           (unsigned long)(a * 255)];
-    
+
     UIImage *borderImage = [[[self class] coloredBorderImageCache] objectForKey:cacheKey];
     if (borderImage == nil)
     {
         UIImage *maskImage = [self maskingImageForCornerRadius:radius width:width];
         borderImage = [self borderImageWithMaskImage:maskImage color:color];
-        
+
         if (borderImage)
         {
             [[[self class] coloredBorderImageCache] setObject:borderImage forKey:cacheKey];
         }
     }
-    
+
     return borderImage;
 }
 
 - (UIImage *)borderImageWithMaskImage:(UIImage *)maskImage color:(UIColor *)color
 {
     UIImage *borderImage = nil;
-    
+
     if (maskImage)
     {
         CGSize imgSize = maskImage.size;
-        
-        UIGraphicsBeginImageContextWithOptions(imgSize, NO, [[UIScreen mainScreen] scale]);
-        
+
+        UIGraphicsBeginImageContextWithOptions(imgSize, NO, fminf(kRZBorderMaxScale, [[UIScreen mainScreen] scale]));
+
         CGContextRef ctx = UIGraphicsGetCurrentContext();
-        
+
         CGRect fullRect = (CGRect){CGPointZero, imgSize};
-        
+
         // draw color border
         CGContextSetFillColorWithColor(ctx, [color CGColor]);
         CGContextFillRect(ctx, fullRect);
-        
+
         // mask it out
         CGContextSetBlendMode(ctx, kCGBlendModeDestinationIn);
         CGContextDrawImage(ctx, fullRect, [maskImage CGImage]);
-        
+
         UIEdgeInsets stretchInsets = UIEdgeInsetsMake(floor(imgSize.height * 0.5), floor(imgSize.width * 0.5), floor(imgSize.height * 0.5), floor(imgSize.width * 0.5));
-        
+
         borderImage = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:stretchInsets
                                                                                   resizingMode:UIImageResizingModeStretch];
         UIGraphicsEndImageContext();


### PR DESCRIPTION
This allows for the borders to layout properly on 6 and 6+

Note the underlying implementation of the borders should be changed, however this is a good quick fix. A better way to go about adding borders would be to start using 1 px "hairline" views instead of trying to draw the borders manually.