### PR TITLE
The Keyboard observer shouldn't force the view to update its layout.

### DIFF
--- a/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
+++ b/RZUtils/Categories/UIViewController/UIViewController+RZKeyboardWatcher.m
@@ -79,7 +79,6 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
                          animations:^{
                              if ( wSelf.animationBlock ) {
                                  wSelf.animationBlock(keyboardVisible, keyboardFrame);
-                                 [wSelf.viewController.view layoutIfNeeded];
                              }
                          }
                          completion:self.completionBlock];
@@ -87,7 +86,6 @@ static void *kRZKeyboardAnimationsDelegateKey = &kRZKeyboardAnimationsDelegateKe
     else {
         if ( self.animationBlock ) {
             self.animationBlock(keyboardVisible, keyboardFrame);
-            [self.viewController.view layoutIfNeeded];
             if ( self.completionBlock ) {
                 self.completionBlock(YES);
             }


### PR DESCRIPTION
The Keyboard observer shouldn't force the view to update its layout.  The view should control when and if it want's to do this in it's animation block.