### PR TITLE
RZCollectionTableViewLayout footerHeight value not used

### DIFF
--- a/RZUtils/Components/RZCollectionTableView/RZCollectionTableView.m
+++ b/RZUtils/Components/RZCollectionTableView/RZCollectionTableView.m
@@ -446,7 +446,7 @@ NSString *const RZCollectionTableViewLayoutFooterView = @"RZCollectionTableViewL
 
 - (CGFloat)footerHeightForSection:(NSInteger)section
 {
-    CGFloat height = 0.f;
+    CGFloat height = self.footerHeight;
     if ( [self.layoutDelegate respondsToSelector:@selector(collectionView:rzTableLayout:heightForFooterInSection:)] ) {
         NSNumber *cachedHeight = [self.footerHeightCache objectForKey:@(section)];
         if ( cachedHeight != nil ) {


### PR DESCRIPTION
- Using footerHeight value as default footer height value instead of 0