### PR TITLE
Remove the deviceName() function

### DIFF
--- a/RZUtils/Components/RZAbout/RZAbout.m
+++ b/RZUtils/Components/RZAbout/RZAbout.m
@@ -193,9 +193,7 @@
 {
     struct utsname systemInfo;
     uname(&systemInfo);
-
-    NSString *deviceName = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-    return deviceName ?: NSLocalizedString(@"Unknown", nil);
+    return @(systemInfo.machine) ?: NSLocalizedString(@"Unknown", nil);
 }
 
 + (NSString *)appInfoText

--- a/RZUtils/Components/RZAbout/RZAbout.m
+++ b/RZUtils/Components/RZAbout/RZAbout.m
@@ -191,7 +191,11 @@
 
 + (NSString *)deviceModel
 {
-    return deviceName() ?: NSLocalizedString(@"Unknown", nil);
+    struct utsname systemInfo;
+    uname(&systemInfo);
+
+    NSString *deviceName = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    return deviceName ?: NSLocalizedString(@"Unknown", nil);
 }
 
 + (NSString *)appInfoText
@@ -201,15 +205,6 @@
     str = [str stringByAppendingFormat:NSLocalizedString(@"iOS Version: %@", nil), [self systemVersion]];
 
     return str;
-}
-
-NSString *deviceName()
-{
-    struct utsname systemInfo;
-    uname(&systemInfo);
-
-    return [NSString stringWithCString:systemInfo.machine
-                              encoding:NSUTF8StringEncoding];
 }
 
 @end


### PR DESCRIPTION
Merging the `deviceName()` function into the `+[RZAbout deviceModel]` implementation since the function is only used in a single spot, and is not public. This also prevents name collisions since the function was not marked as `static`.

@nbonatsakis 